### PR TITLE
Add support for range requests in the simple backend

### DIFF
--- a/sendfile/backends/simple.py
+++ b/sendfile/backends/simple.py
@@ -32,7 +32,6 @@ def sendfile(request, filename, **kwargs):
 
     response = StreamingHttpResponse(fileiter)
     response["Last-Modified"] = http_date(statobj[stat.ST_MTIME])
-    response['Accept-Ranges'] = 'bytes'
 
     # Parse range request, if any
     start = None
@@ -40,7 +39,7 @@ def sendfile(request, filename, **kwargs):
 
     range_request = request.META.get('HTTP_RANGE', '').strip()
     m = re.match(r'^bytes=(?P<start>\d+)?-(?P<stop>\d+)?$', range_request)
-    if m:
+    if m and kwargs.get('accept_ranges', False):
         start, stop = m.groups()
         try:
             if start is not None:


### PR DESCRIPTION
It might be useful to have support for HTTP range requests also when using the simple backend. Here's a relatively straightforward implementation for that + some tests.

The range requests are here enabled only for Django 1.5, which apparently has a more sensible support for streaming.
