### PR TITLE
Only provide attachment filename explicitly, to allow unicode filenames.

### DIFF
--- a/sendfile/__init__.py
+++ b/sendfile/__init__.py
@@ -58,8 +58,10 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
         
     response = _sendfile(request, filename, mimetype=mimetype)
     if attachment:
-        attachment_filename = attachment_filename or os.path.basename(filename)
-        response['Content-Disposition'] = 'attachment; filename="%s"' % attachment_filename
+        if attachment_filename:
+            response['Content-Disposition'] = 'attachment; filename="%s"' % attachment_filename
+        else:
+            response['Content-Disposition'] = 'attachment'
 
     response['Content-length'] = os.path.getsize(filename)
     response['Content-Type'] = mimetype


### PR DESCRIPTION
The Content-Disposition header can be used without passing in a filename
parameter: in that case, the filename will be the last portion of the
url path.

Leaving off the filename parameter, and pulling the value from the url
string automatically allows for unicode strings to be used as filenames:
otherwise django specifically prohibits non-ascii strings, which used to
be part of the specification (and is the only way that is guaranteed to
work in all browsers).

This patch will only set the parameter if it is explicitly passed in in the
sendfile function. It may break existing code, where a reliance on the
filename is implicit. This code could be fixed by instead of calling:

```
 sendfile(request, file, True)
```

using:

```
 sendfile(request, file, True, os.path.basename(file))
```
