### PR TITLE
Added no_file_check to sendfile for remote proxy case

### DIFF
--- a/sendfile/__init__.py
+++ b/sendfile/__init__.py
@@ -98,7 +98,7 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
     if not no_file_check:
         response['Content-length'] = os.path.getsize(filename)
     response['Content-Type'] = mimetype
-    if not encoding:
+    if not encoding and not no_file_check:
         encoding = guessed_encoding
     if encoding:
         response['Content-Encoding'] = encoding


### PR DESCRIPTION
Makes sendfile useful for object stores (eg S3) when running behind a proxying webserver.

eg: http://distinctplace.com/infrastructure/2013/09/18/use-nginx-to-proxy-files-from-remote-location-using-x-accel-redirect/
