### PR TITLE
Allow backend to be passed in to sendfile()

### DIFF
--- a/sendfile/__init__.py
+++ b/sendfile/__init__.py
@@ -32,7 +32,7 @@ def _get_sendfile():
 
 
 
-def sendfile(request, filename, attachment=False, attachment_filename=None, mimetype=None, encoding=None):
+def sendfile(request, filename, attachment=False, attachment_filename=None, mimetype=None, encoding=None, backend=None):
     '''
     create a response to send file using backend configured in SENDFILE_BACKEND
 
@@ -48,7 +48,7 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
     If no mimetype or encoding are specified, then they will be guessed via the
     filename (using the standard python mimetypes module)
     '''
-    _sendfile = _get_sendfile()
+    _sendfile = backend or _get_sendfile()
 
     if not os.path.exists(filename):
         from django.http import Http404

--- a/sendfile/tests.py
+++ b/sendfile/tests.py
@@ -87,6 +87,20 @@ class TestSendfile(TempFileTestCase):
         self.assertTrue(response is not None)
         self.assertEqual('attachment; filename="test\'s.txt"; filename*=UTF-8\'\'test%E2%80%99s.txt', response['Content-Disposition'])
 
+    def test_override_backend(self):
+        def overriden_sendfile(*args, **kwargs):
+            # Add an extra header to the respone
+            response = sendfile(*args, **kwargs)
+            response['X-Backend-Overriden'] = 'yes'
+            return response
+
+        response = real_sendfile(HttpRequest(), self._get_readme(), backend=overriden_sendfile)
+        self.assertTrue(response is not None)
+        self.assertEqual('text/plain', response['Content-Type'])
+        self.assertEqual(self._get_readme(), smart_str(response.content))
+
+        self.assertEqual('yes', response['X-Backend-Overriden'])
+
 
 class TestXSendfileBackend(TempFileTestCase):
 


### PR DESCRIPTION
This pull request adds a ``kwarg`` called ``backend`` to ``sendfile()``. It allows a different backend to be used for a particular view. It is also useful for third-party apps that want to use sendfile but provide a fallback if their users haven't set ``SENDFILE_BACKEND``.

Example:

```python
    from sendfile import sendfile
    from sendfile.backends.simple import sendfile as simple_sendfile

    def myview(request):
        ...

        return sendfile(..., backend=simple_sendfile)
```