### PR TITLE
Remove calculation of Content-Length.

### DIFF
--- a/sendfile/__init__.py
+++ b/sendfile/__init__.py
@@ -85,7 +85,6 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
                 parts.append('filename*=UTF-8\'\'%s' % quoted_filename)
         response['Content-Disposition'] = '; '.join(parts)
 
-    response['Content-length'] = os.path.getsize(filename)
     response['Content-Type'] = mimetype
     if not encoding:
         encoding = guessed_encoding


### PR DESCRIPTION
mod_xsendfile unconditionally removes the Content-Length header as it
will always be recalculated when serving the passed file. Calculating it
in Django is a waste.

URL to where mod_xsendfile removes this header. See:

https://github.com/nmaier/mod_xsendfile/blob/1480b2dd27ebe08cc47e84f4666f6df2b28a79b5/mod_xsendfile.c#L396-L397
