### PR TITLE
Added url quoting to X-Accel-Redirect and Location header

### DIFF
--- a/sendfile/backends/_internalredirect.py
+++ b/sendfile/backends/_internalredirect.py
@@ -1,7 +1,7 @@
 import os.path
 
 from django.conf import settings
-from django.utils.encoding import force_text, force_bytes
+from django.utils.encoding import smart_text, smart_bytes
 
 try:
     from urllib.parse import quote
@@ -19,6 +19,6 @@ def _convert_file_to_url(filename):
         url.insert(1, head)
 
     # Python3 urllib.parse.quote accepts both unicode and bytes, while Python2 urllib.quote only accepts bytes.
-    # So force bytes for quoting and then go back to unicode.
-    url = [force_bytes(url_component) for url_component in url]
-    return force_text(quote(b'/'.join(url)))
+    # So use bytes for quoting and then go back to unicode.
+    url = [smart_bytes(url_component) for url_component in url]
+    return smart_text(quote(b'/'.join(url)))

--- a/sendfile/backends/_internalredirect.py
+++ b/sendfile/backends/_internalredirect.py
@@ -1,5 +1,12 @@
-from django.conf import settings
 import os.path
+
+from django.conf import settings
+from django.utils.encoding import force_text, force_bytes
+
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
 
 
 def _convert_file_to_url(filename):
@@ -11,4 +18,7 @@ def _convert_file_to_url(filename):
         relpath, head = os.path.split(relpath)
         url.insert(1, head)
 
-    return u'/'.join(url)
+    # Python3 urllib.parse.quote accepts both unicode and bytes, while Python2 urllib.quote only accepts bytes.
+    # So force bytes for quoting and then go back to unicode.
+    url = [force_bytes(url_component) for url_component in url]
+    return force_text(quote(b'/'.join(url)))

--- a/sendfile/tests.py
+++ b/sendfile/tests.py
@@ -9,6 +9,11 @@ from tempfile import mkdtemp
 import shutil
 from sendfile import sendfile as real_sendfile, _get_sendfile
 
+try:
+    from urllib.parse import unquote
+except ImportError:
+    from urllib import unquote
+
 
 def sendfile(request, filename, **kwargs):
     # just a simple response with the filename
@@ -127,4 +132,26 @@ class TestNginxBackend(TempFileTestCase):
         filepath = self.ensure_file(u'péter_là_gueule.txt')
         response = real_sendfile(HttpRequest(), filepath)
         self.assertTrue(response is not None)
-        self.assertEqual(u'/private/péter_là_gueule.txt'.encode('utf-8'), response['X-Accel-Redirect'])
+        self.assertEqual(u'/private/péter_là_gueule.txt'.encode('utf-8'), unquote(response['X-Accel-Redirect']))
+
+
+class TestModWsgiBackend(TempFileTestCase):
+
+    def setUp(self):
+        super(TestModWsgiBackend, self).setUp()
+        settings.SENDFILE_BACKEND = 'sendfile.backends.mod_wsgi'
+        settings.SENDFILE_ROOT = self.TEMP_FILE_ROOT
+        settings.SENDFILE_URL = '/private'
+        _get_sendfile.clear()
+
+    def test_correct_url_in_location_header(self):
+        filepath = self.ensure_file('readme.txt')
+        response = real_sendfile(HttpRequest(), filepath)
+        self.assertTrue(response is not None)
+        self.assertEqual('/private/readme.txt', response['Location'])
+
+    def test_location_header_containing_unicode(self):
+        filepath = self.ensure_file(u'péter_là_gueule.txt')
+        response = real_sendfile(HttpRequest(), filepath)
+        self.assertTrue(response is not None)
+        self.assertEqual(u'/private/péter_là_gueule.txt'.encode('utf-8'), unquote(response['Location']))


### PR DESCRIPTION
This fix is as unintrusive as I could make it.
All the tests pass on Python2.  As you know many tests fail on Python3.

I successfully tested this with a Nginx setup on PY2 and PY3.
I couldn't test this on Apache2 as I'm really unfamiliar with the setup.

Is there anything else you need? 