### PR TITLE
nginx X-Accel-Redirect requires unquoted URLs.

### DIFF
--- a/sendfile/backends/_internalredirect.py
+++ b/sendfile/backends/_internalredirect.py
@@ -9,7 +9,7 @@ except ImportError:
     from urllib import quote
 
 
-def _convert_file_to_url(filename):
+def _convert_file_to_url(filename, quote_url=True):
     relpath = os.path.relpath(filename, settings.SENDFILE_ROOT)
 
     url = [settings.SENDFILE_URL]
@@ -21,4 +21,7 @@ def _convert_file_to_url(filename):
     # Python3 urllib.parse.quote accepts both unicode and bytes, while Python2 urllib.quote only accepts bytes.
     # So use bytes for quoting and then go back to unicode.
     url = [smart_bytes(url_component) for url_component in url]
-    return smart_text(quote(b'/'.join(url)))
+    url = b'/'.join(url)
+    if quote_url:
+        url = quote(url)
+    return smart_text(url)

--- a/sendfile/backends/nginx.py
+++ b/sendfile/backends/nginx.py
@@ -7,7 +7,7 @@ from ._internalredirect import _convert_file_to_url
 
 def sendfile(request, filename, **kwargs):
     response = HttpResponse()
-    url = _convert_file_to_url(filename)
+    url = _convert_file_to_url(filename, quote_url=False)
     response['X-Accel-Redirect'] = url.encode('utf-8')
 
     return response


### PR DESCRIPTION
As the title says, nginx X-Accel-Redirect expects an unquoted string.

Therefore quoting the URL in the nginx backend will cause internal 404s.