### PR TITLE
backends-nginx: Add support for Nginx versions older than 1.5.9.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,13 +11,13 @@ The interface is a single function `sendfile(request, filename, attachment=False
 ::
 
     from sendfile import sendfile
-    
+
     # send myfile.pdf to user
     return sendfile(request, '/home/john/myfile.pdf')
 
     # send myfile.pdf as an attachment (with name myfile.pdf)
     return sendfile(request, '/home/john/myfile.pdf', attachment=True)
-    
+
     # send myfile.pdf as an attachment with a different name
     return sendfile(request, '/home/john/myfile.pdf', attachment=True, attachment_filename='full-name.pdf')
 
@@ -134,8 +134,13 @@ Then the matching location block in nginx.conf would be:
 
 You need to pay attention to whether you have trailing slashes or not on the SENDFILE_URL and root values, otherwise you may not get the right URL being sent to NGINX and you may get 404s.  You should be able to see what file NGINX is trying to load in the error.log if this happens.  From there it should be fairly easy to work out what the right settings are.
 
+Also if you are willing to use django-sendfile with Nginx older than 1.5.9, you need to setup the configuration setting in django settings for specifying Nginx version like this:
+
+::
+
+    NGINX_VERSION = '1.4.6'
+
 .. _mod_xsendfile: https://tn123.org/mod_xsendfile/
 .. _Apache: http://httpd.apache.org/
 .. _Lighthttpd: http://www.lighttpd.net/
 .. _mod_wsgi: http://code.google.com/p/modwsgi/
-

--- a/sendfile/backends/_internalredirect.py
+++ b/sendfile/backends/_internalredirect.py
@@ -9,6 +9,28 @@ except ImportError:
     from urllib import quote
 
 
+def _decision(fn):
+    _cached_decision = []
+    def _decorated():
+        if not _cached_decision:
+            _cached_decision.append(fn())
+        return _cached_decision[0]
+    return _decorated
+
+@_decision
+def should_be_quoted():
+    backend = getattr(settings, 'SENDFILE_BACKEND', None)
+    if backend == 'sendfile.backends.nginx':
+        nginx_version = getattr(settings, 'NGINX_VERSION', None)
+        if nginx_version:
+            nginx_version = map(int, nginx_version.split('.'))
+            # Since Starting with Nginx 1.5.9, quoted url's are expected to be
+            # sent with X-Accel-Redirect headers, we will not quote url's for
+            # versions of Nginx before 1.5.9
+            if nginx_version < [1, 5, 9]:
+                return False
+    return True
+
 def _convert_file_to_url(filename):
     relpath = os.path.relpath(filename, settings.SENDFILE_ROOT)
 
@@ -21,4 +43,7 @@ def _convert_file_to_url(filename):
     # Python3 urllib.parse.quote accepts both unicode and bytes, while Python2 urllib.quote only accepts bytes.
     # So use bytes for quoting and then go back to unicode.
     url = [smart_bytes(url_component) for url_component in url]
-    return smart_text(quote(b'/'.join(url)))
+    if should_be_quoted():
+        return smart_text(quote(b'/'.join(url)))
+    else:
+        return smart_text(b'/'.join(url))


### PR DESCRIPTION
In this PR we are adding support for Nginx version older than 1.5.9. This is achieved through conditionally quoting the URL's in X-Accel-Redirect headers according to compatibility with Nginx. Since newer versions of Nginx expect URL's in X-Accel-Redirect to be quoted unlike the versions older that Nginx 1.5.9. In this commit we start to check the Nginx version using 'nginx -v' and then caching the result be making use of a decorator. Using this result we decide whether the outgoing URL should be quoted or not.
This will not break Unicode support as revealed from my investigation. I tried out Django-sendfile 0.3.11 with Nginx 1.4.6. This leads to 404's which are resolved when we stop quoting the URL's. It might be worthwhile mentioning after making such a change filenames such as `á.txt` and `Б.txt` were still functional and correctly recognised.
Fixes: #56, #58. Closes #45.