### PR TITLE
Fix `ascii_filename` to work properly in Python 3

### DIFF
--- a/sendfile/__init__.py
+++ b/sendfile/__init__.py
@@ -2,6 +2,7 @@ VERSION = (0, 3, 11)
 __version__ = '.'.join(map(str, VERSION))
 
 import os.path
+import sys
 from mimetypes import guess_type
 import unicodedata
 
@@ -78,6 +79,9 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
                 from django.utils.encoding import force_unicode as force_text
             attachment_filename = force_text(attachment_filename)
             ascii_filename = unicodedata.normalize('NFKD', attachment_filename).encode('ascii','ignore') 
+            if sys.version_info[0] >= 3:
+                # We want ascii_filename as a unicode string, since it will be formatted into parts
+                ascii_filename = ascii_filename.decode('ascii')
             parts.append('filename="%s"' % ascii_filename)
             if ascii_filename != attachment_filename:
                 from django.utils.http import urlquote


### PR DESCRIPTION
This fixes issue #49. In Python 3 the result of `str.encode()` is `bytes` and so `"something %s" % (b'else') == `"something b'else'"`, which `2to3` does not catch because of the `str`-`bytes` ambiguity in Python 2 (see also [here](https://bugs.python.org/issue38003)). I suggest simply reconverting the ASCII-bytes into a Unicode string (containing only ASCII characters) for Python 3. Actually, the version check is redundant, as in Python 2 I think

    s = s.encode('ascii', 'ignore')
    assert s.decode('ascii') == s

Is always true.

I haven't tested this code.