### PR TITLE
Fix compatibility with Django 4.0

### DIFF
--- a/examples/protected_downloads/download/models.py
+++ b/examples/protected_downloads/download/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
+from django.urls import reverse
 
 sendfile_storage = FileSystemStorage(location=settings.SENDFILE_ROOT)
 
@@ -20,6 +21,5 @@ class Download(models.Model):
     def __unicode__(self):
         return self.title
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('download', [self.pk], {})
+        return reverse('download', args=[self.pk])

--- a/examples/protected_downloads/download/urls.py
+++ b/examples/protected_downloads/download/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls.defaults import *
+from django.urls import re_path
 
 from .views import download, download_list
 
-urlpatterns = patterns('',
-    url(r'^$', download_list),
-    url(r'(?P<download_id>\d+)/$', download, name='download'),
-)
+urlpatterns = [
+    re_path(r'^$', download_list),
+    re_path(r'(?P<download_id>\d+)/$', download, name='download'),
+]

--- a/examples/protected_downloads/download/views.py
+++ b/examples/protected_downloads/download/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import get_object_or_404, render_to_response
+from django.shortcuts import get_object_or_404, render
 from django.http import HttpResponseForbidden
 from django.db.models import Q
 from django.template import RequestContext
@@ -29,6 +29,6 @@ def download_list(request):
         downloads = downloads.filter(Q(is_public=True) | Q(users=request.user))
     else:
         downloads = downloads.filter(is_public=True)
-    return render_to_response('download/download_list.html',
-                              {'download_list': downloads},
-                              context_instance=RequestContext(request))
+    return render(request, 'download/download_list.html',
+                  {'download_list': downloads},
+                  context_instance=RequestContext(request))

--- a/examples/protected_downloads/settings.py
+++ b/examples/protected_downloads/settings.py
@@ -61,10 +61,29 @@ TEMPLATE_LOADERS = (
     # 'django.template.loaders.eggs.load_template_source',
 )
 
-MIDDLEWARE_CLASSES = (
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.abspath(os.path.join(os.path.dirname(__file__), 'templates')
+),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ]
+        }
+    },
+]
+
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
 )
 
 ROOT_URLCONF = 'protected_downloads.urls'
@@ -79,7 +98,8 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.admin',
-    'download',
+    'django.contrib.messages',
+    'protected_downloads.download',
     'sendfile',
 )
 

--- a/examples/protected_downloads/urls.py
+++ b/examples/protected_downloads/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls.defaults import *
+from django.urls import include, re_path, path
 
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    (r'^', include('protected_downloads.download.urls')),
-    (r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    re_path(r'^', include('protected_downloads.download.urls')),
+]

--- a/sendfile/backends/_internalredirect.py
+++ b/sendfile/backends/_internalredirect.py
@@ -1,7 +1,11 @@
 import os.path
 
 from django.conf import settings
-from django.utils.encoding import smart_text, smart_bytes
+from django.utils.encoding import smart_bytes
+try:
+    from django.utils.encoding import smart_str as smart_text
+except ImportError:
+    from django.utils.encoding import smart_text
 
 try:
     from urllib.parse import quote

--- a/sendfile/backends/xsendfile.py
+++ b/sendfile/backends/xsendfile.py
@@ -1,8 +1,9 @@
 from django.http import HttpResponse
+from django.utils.encoding import force_str
 
 
 def sendfile(request, filename, **kwargs):
     response = HttpResponse()
-    response['X-Sendfile'] = unicode(filename).encode('utf-8')
+    response['X-Sendfile'] = force_str(filename)
 
     return response

--- a/sendfile/tests.py
+++ b/sendfile/tests.py
@@ -132,7 +132,7 @@ class TestNginxBackend(TempFileTestCase):
         filepath = self.ensure_file(u'péter_là_gueule.txt')
         response = real_sendfile(HttpRequest(), filepath)
         self.assertTrue(response is not None)
-        self.assertEqual(u'/private/péter_là_gueule.txt'.encode('utf-8'), unquote(response['X-Accel-Redirect']))
+        self.assertEqual(u'/private/péter_là_gueule.txt', unquote(response['X-Accel-Redirect']))
 
 
 class TestModWsgiBackend(TempFileTestCase):
@@ -154,4 +154,4 @@ class TestModWsgiBackend(TempFileTestCase):
         filepath = self.ensure_file(u'péter_là_gueule.txt')
         response = real_sendfile(HttpRequest(), filepath)
         self.assertTrue(response is not None)
-        self.assertEqual(u'/private/péter_là_gueule.txt'.encode('utf-8'), unquote(response['Location']))
+        self.assertEqual(u'/private/péter_là_gueule.txt', unquote(response['Location']))


### PR DESCRIPTION
This change makes `django-sendfile` work with Django 4.0, including tests.